### PR TITLE
SPH-224 - add networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,10 @@ services:
       target: phptools
     volumes:
       - ./:/srv/paygreen:rw,cached
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.57.0/24


### PR DESCRIPTION
Ajout d'un subnet spécifique pour lancer le container avec le VPN Paygreen activé